### PR TITLE
explicitly use python2 in all scripts

### DIFF
--- a/bin/ophis
+++ b/bin/ophis
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from os.path import realpath, dirname, join
 from sys import argv, exit, path

--- a/src/scripts/ophis
+++ b/src/scripts/ophis
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python2
 import sys
 import Ophis.Main
 

--- a/src/tools/charmaps/makea2maps.py
+++ b/src/tools/charmaps/makea2maps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 import struct
 
 x = ''.join([chr(x) for x in range(256)])

--- a/src/tools/opcodes/gensets.py
+++ b/src/tools/opcodes/gensets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 import sys
 
 verbose = 0

--- a/tests/test_ophis.py
+++ b/tests/test_ophis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import sys
 import subprocess


### PR DESCRIPTION
Fixes errors on systems which have python3 as default interpreter.
This is a hack. Ideally this should be made forward compatible
with python3.